### PR TITLE
Projects

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -1,6 +1,0 @@
----
-title: Work With Us
-permalink: /projects/
----
-
-<h1>Projects by Dashboard</h1>

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,36 @@
+---
+title: Projects
+permalink: /projects/
+---
+
+## CTO Projects
+
+### cto.gsa.gov
+A new GSA website that will provide guidance to GSA IT as it drives towards adopting modern IT practices.  Including Agile practices, modern IT development, open data, APIs, etc.  Also include information for GSA employees and potential new hires.
+
+Contact: [cto@gsa.gov](mailto:cto@gsa.gov)
+
+### open.gsa.gov
+open.gsa.gov is the current developer portal for all GSA data, APIs, and code open to the public.  The focus of this project is the redesign of the site, offering a new, user-focused experience emphasizing engagement with the public.
+
+Contact: [sara.cope@gsa.gov](mailto:sara.cope@gsa.gov)
+
+### Open Opportunities
+Open Opportunities is a site offering detail opportunities across government agencies.  Agency representatives and current government employees can post/find opportunities to participate on various projects, usually IT oriented.
+
+Contact: [openopps@gsa.gov](mailto:openopps@gsa.gov)
+
+### Federal Innovation Toolkit
+Development of the Federal Challenges & Prizes Toolkit to fulfill the President's commitment  to improve public services through support of open innovation by harnessing the ingenuity of the american public (as outlined in the 2nd Open Government National Action Plan).
+
+Contact: [challenge@gsa.gov](mailto:challenge@gsa.gov)
+
+### PBS Comfort App
+Utilizing environmental sensor data at GSA to create an application to integrate with hoteling and reserving workspaces in GSA buildings.  Allows users to pick where to sit based on temperature, light, sound, etc.
+
+Contact: [jeffrey.fredrickson@gsa.gov](mailto:jeffrey.fredrickson@gsa.gov)
+
+### National Staffing Application
+Application within GSA managed by GSA IT Corporate Solutions providing data and reports pertaining to staffing.  Allows for budget and personnel current views and forecasting.
+
+Contact: [joseph.castle@gsa.gov](mailto:joseph.castle@gsa.gov)


### PR DESCRIPTION
This switches the projects page to markdown so it can be edited directly through Federalist and fills it in with a base project listing to start with.