### PR TITLE
Publish future posts (for TechTalks)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,9 @@ plugins:
   - jekyll-sitemap
   - jekyll-redirect-from
 
+# Publish posts that have a date in the future
+future: true
+
 collections:
   team:
     permalink: /team/:name/


### PR DESCRIPTION
Jekyll started to hold postdated items without publishing them. This affects Tech Talks that specify a date in the future. Fix this by enabling the `future` option in the Jekyll config.