### PR TITLE
update index.json path to reflect / in baseurl

### DIFF
--- a/static/assets/js/search.js
+++ b/static/assets/js/search.js
@@ -8,7 +8,7 @@
   function initSearchPage() {
     var searchTerm = getSearchQuery();
     if (searchTerm) {
-      var url = baseurl + "/index.json";
+      var url = baseurl + "index.json";
       var xhr = new XMLHttpRequest();
       xhr.open("GET", url, true);
       xhr.onload = function () {


### PR DESCRIPTION
The site's baseurl global variable now has a trailing slash. Update the search index path to remove the extraneous slash.