### PR TITLE
Removes `<br>` from hero

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,6 @@
     <div class="grid-container">
       <div class="techgsa-hero__intro">
         <h1>Modernizing GSA Technology</h1>
-        <br>
         <p>{{ .Site.Params.Description }}</p>
       </div>
     </div>


### PR DESCRIPTION
I meant to include this in #857, but this removes the `<br>` and the accompanying (excessive) space in between the `h1` and `description`.