### PR TITLE
pa11y should ignore iframes

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -1,8 +1,0 @@
-{
-  "defaults": {
-    "concurrency": 1,
-    "chromeLaunchConfig": {
-      "args": ["--no-sandbox"]
-    }
-  }
-}

--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -1,0 +1,11 @@
+module.exports = {
+  defaults: {
+    concurrency: 1,
+    // We're ignoring iframe elements because they're not used on the site, yet
+    // DAP inserts an iframe into the DOM, and that iframe causes pa11y errors.
+    hideElements: "iframe",
+    chromeLaunchConfig: {
+      args: ["--no-sandbox"]
+    },
+  },
+};


### PR DESCRIPTION
The DAP scripts inserts an `iframe` into the DOM, and that `iframe` is not accessible (which it doesn't have to be, since it's just for internal Google Tag Manager shenanigans). This causes some sort of apparent race condition where `pa11y-ci` throws an error on random pages during automated tests. Our workaround is to tell `pa11y-ci` to ignore `iframe` elements, which is okay because the site doesn't otherwise use `iframe`s.