### PR TITLE
Display only Tech Talks from the past two years

### DIFF
--- a/content/techtalks/_index.md
+++ b/content/techtalks/_index.md
@@ -2,6 +2,11 @@
 title: Tech Talks
 menu:
   primary:
+build:
+  render: always
+cascade:
+  - build:
+      render: never
 ---
 
 The GSA CTO team hosts in-depth Tech Talks, where presenters discuss technology topics affecting the agency. Each Tech Talk is a 30-minute informal meeting with an audience of internal GSA members. Demonstrations are often provided along with follow-up Q&A. Registration is limited to internal GSA personnel. To register to attend a Tech Talk event, please contact Joe Novak at [Joseph.Novak@gsa.gov](mailto:Joseph.Novak@gsa.gov).

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,7 +1,7 @@
 {{/*  Based on:  */}}
 {{/*  https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/pagination.html  */}}
 
-{{ $pag := $.Paginator }}
+{{ $pag := . }}
 
 {{ if gt $pag.TotalPages 1 -}}
   <nav aria-label="Pagination" class="usa-pagination">

--- a/layouts/techtalks/list.html
+++ b/layouts/techtalks/list.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+  {{ $twoYearsAgo := now.AddDate -2 0 0 }}
+  {{ $recentTechTalks := where .Pages "Date" "ge" $twoYearsAgo }}
+  {{ $paginator := .Paginate $recentTechTalks }}
 
   <div class="grid-container">
 
@@ -6,10 +9,10 @@
 
     {{ .Content }}
 
-    {{ partial "pagination.html" . }}
+    {{ partial "pagination.html" $paginator }}
 
     <ul class="usa-card-group">
-      {{ range .Paginator.Pages }}
+      {{ range $paginator.Pages }}
         <li class="tablet:grid-col-12 usa-card">
           <div class="usa-card__container">
             <header class="usa-card__header">
@@ -42,7 +45,7 @@
       {{ end }}
     </ul>
 
-    {{ partial "pagination.html" . }}
+    {{ partial "pagination.html" $paginator }}
 
   </div>
 


### PR DESCRIPTION
This adds a filter to the Tech Talks page so that only Tech Talks from the past two years are listed (#888)